### PR TITLE
Add FastAPI IoT server skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# IoT Energy Monitoring Server
+
+Simple FastAPI application for receiving sensor data, generating alerts and managing settings.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+## Features
+
+- User registration and login with JWT authentication
+- Receive sensor data from IoT systems
+- Store data and generate alerts when values are out of bounds
+- Manage threshold settings for sensors

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from jose import jwt
+from datetime import timedelta
+
+from database import User
+from auth_utils import (
+    get_db,
+    verify_password,
+    get_password_hash,
+    create_access_token,
+    ACCESS_TOKEN_EXPIRE_MINUTES,
+)
+
+router = APIRouter(prefix="/api/v1")
+
+
+@router.post("/register")
+def register(username: str, email: str, password: str, db: Session = Depends(get_db)):
+    existing_user = db.query(User).filter(User.username == username).first()
+    if existing_user:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    user = User(
+        username=username,
+        email=email,
+        password_hash=get_password_hash(password),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return {"message": "User created"}
+
+
+@router.post("/login")
+def login(username: str, password: str, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.username == username).first()
+    if not user or not verify_password(password, user.password_hash):
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(
+        data={"sub": user.username}, expires_delta=access_token_expires
+    )
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -1,0 +1,61 @@
+from datetime import datetime, timedelta
+from jose import JWTError, jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from database import SessionLocal, User
+
+SECRET_KEY = "secret"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/login")
+
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_current_user(db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = db.query(User).filter(User.username == username).first()
+    if user is None:
+        raise credentials_exception
+    return user

--- a/database.py
+++ b/database.py
@@ -1,0 +1,89 @@
+from sqlalchemy import (Column, Integer, String, Float, ForeignKey, DateTime)
+from sqlalchemy.orm import relationship, declarative_base, sessionmaker
+from sqlalchemy import create_engine
+from datetime import datetime
+
+DATABASE_URL = "sqlite:///./iot_system.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True)
+    email = Column(String, unique=True, index=True)
+    password_hash = Column(String)
+    role = Column(String, default="user")
+
+    systems = relationship("UserIoTLink", back_populates="user")
+
+class IoTSystem(Base):
+    __tablename__ = "iot_systems"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+    password_hash = Column(String)
+
+    sensors = relationship("Sensor", back_populates="iot_system")
+    settings = relationship("Setting", back_populates="iot_system")
+
+class UserIoTLink(Base):
+    __tablename__ = "user_iot_link"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    iot_system_id = Column(Integer, ForeignKey("iot_systems.id"))
+
+    user = relationship("User", back_populates="systems")
+    iot_system = relationship("IoTSystem")
+
+class Sensor(Base):
+    __tablename__ = "sensors"
+
+    id = Column(Integer, primary_key=True, index=True)
+    serial_number = Column(String, unique=True, index=True)
+    type = Column(String)
+    location = Column(String)
+    iot_system_id = Column(Integer, ForeignKey("iot_systems.id"))
+
+    iot_system = relationship("IoTSystem", back_populates="sensors")
+    data = relationship("SensorData", back_populates="sensor")
+
+class SensorData(Base):
+    __tablename__ = "sensor_data"
+
+    id = Column(Integer, primary_key=True, index=True)
+    sensor_id = Column(Integer, ForeignKey("sensors.id"))
+    value = Column(Float)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    sensor = relationship("Sensor", back_populates="data")
+
+class Setting(Base):
+    __tablename__ = "settings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    iot_system_id = Column(Integer, ForeignKey("iot_systems.id"))
+    sensor_type = Column(String)
+    min_value = Column(Float, nullable=True)
+    max_value = Column(Float, nullable=True)
+
+    iot_system = relationship("IoTSystem", back_populates="settings")
+
+class Alert(Base):
+    __tablename__ = "alerts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    iot_system_id = Column(Integer, ForeignKey("iot_systems.id"))
+    sensor_id = Column(Integer, ForeignKey("sensors.id"))
+    message = Column(String)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+
+def init_db():
+    Base.metadata.create_all(bind=engine)

--- a/iot_sensor_simulator.py
+++ b/iot_sensor_simulator.py
@@ -1,0 +1,21 @@
+import requests
+from datetime import datetime
+
+API_URL = "http://localhost:8000/api/v1/data"
+
+payload = {
+    "iot_system_name": "DemoSystem",
+    "iot_system_password": "demo",
+    "timestamp": datetime.utcnow().isoformat(),
+    "sensor_data": [
+        {
+            "sensor_serial_number": "TEMP1",
+            "type": "temperature",
+            "location": "room1",
+            "value": 25.3,
+        }
+    ],
+}
+
+response = requests.post(API_URL, json=payload)
+print(response.status_code, response.json())

--- a/main.py
+++ b/main.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+
+from database import init_db
+from auth import router as auth_router
+from sensor_routes import router as sensor_router
+
+init_db()
+
+app = FastAPI(title="IoT Energy Monitoring")
+
+app.include_router(auth_router)
+app.include_router(sensor_router)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlalchemy
+python-jose[cryptography]
+passlib[bcrypt]

--- a/sensor_routes.py
+++ b/sensor_routes.py
@@ -1,0 +1,130 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from datetime import datetime
+
+from database import (
+    Sensor,
+    UserIoTLink,
+    SensorData,
+    Setting,
+    Alert,
+    IoTSystem,
+)
+from auth_utils import get_db, get_current_user, get_password_hash, verify_password
+
+router = APIRouter(prefix="/api/v1")
+
+
+@router.post("/data")
+def receive_data(
+    iot_system_name: str,
+    iot_system_password: str,
+    timestamp: datetime,
+    sensor_data: list[dict],
+    db: Session = Depends(get_db),
+):
+    system = db.query(IoTSystem).filter(IoTSystem.name == iot_system_name).first()
+    if not system or not verify_password(iot_system_password, system.password_hash):
+        raise HTTPException(status_code=401, detail="Invalid IoT system")
+
+    for entry in sensor_data:
+        serial = entry["sensor_serial_number"]
+        sensor = db.query(Sensor).filter(Sensor.serial_number == serial).first()
+        if not sensor:
+            sensor = Sensor(
+                serial_number=serial,
+                type=entry["type"],
+                location=entry.get("location"),
+                iot_system_id=system.id,
+            )
+            db.add(sensor)
+            db.commit()
+            db.refresh(sensor)
+        data = SensorData(
+            sensor_id=sensor.id,
+            value=entry["value"],
+            timestamp=timestamp,
+        )
+        db.add(data)
+        # check settings
+        setting = (
+            db.query(Setting)
+            .filter(
+                Setting.iot_system_id == system.id,
+                Setting.sensor_type == sensor.type,
+            )
+            .first()
+        )
+        if setting:
+            if (
+                (setting.min_value is not None and data.value < setting.min_value)
+                or (
+                    setting.max_value is not None
+                    and data.value > setting.max_value
+                )
+            ):
+                alert = Alert(
+                    iot_system_id=system.id,
+                    sensor_id=sensor.id,
+                    message=f"{sensor.type} out of bounds: {data.value}",
+                    timestamp=timestamp,
+                )
+                db.add(alert)
+    db.commit()
+    return {"message": "Data processed"}
+
+
+@router.get("/alerts")
+def get_alerts(current_user=Depends(get_current_user), db: Session = Depends(get_db)):
+    alerts = (
+        db.query(Alert)
+        .join(IoTSystem, Alert.iot_system_id == IoTSystem.id)
+        .join(UserIoTLink, UserIoTLink.iot_system_id == IoTSystem.id)
+        .filter(UserIoTLink.user_id == current_user.id)
+        .all()
+    )
+    return alerts
+
+
+@router.post("/settings")
+def set_setting(
+    sensor_type: str,
+    min_value: float | None = None,
+    max_value: float | None = None,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    link = db.query(UserIoTLink).filter(UserIoTLink.user_id == current_user.id).first()
+    if not link:
+        raise HTTPException(status_code=400, detail="User has no system")
+    setting = (
+        db.query(Setting)
+        .filter(
+            Setting.iot_system_id == link.iot_system_id,
+            Setting.sensor_type == sensor_type,
+        )
+        .first()
+    )
+    if not setting:
+        setting = Setting(
+            iot_system_id=link.iot_system_id,
+            sensor_type=sensor_type,
+            min_value=min_value,
+            max_value=max_value,
+        )
+        db.add(setting)
+    else:
+        setting.min_value = min_value
+        setting.max_value = max_value
+    db.commit()
+    db.refresh(setting)
+    return setting
+
+
+@router.get("/settings")
+def get_settings(current_user=Depends(get_current_user), db: Session = Depends(get_db)):
+    link = db.query(UserIoTLink).filter(UserIoTLink.user_id == current_user.id).first()
+    if not link:
+        raise HTTPException(status_code=400, detail="User has no system")
+    settings = db.query(Setting).filter(Setting.iot_system_id == link.iot_system_id).all()
+    return settings


### PR DESCRIPTION
## Summary
- set up FastAPI project with authentication utilities
- define SQLAlchemy models for users, IoT systems, sensors and alerts
- implement basic auth routes and sensor data endpoints
- add a small sensor simulator script
- document setup steps in README

## Testing
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6848746105cc832cace5486c4d38f304